### PR TITLE
Fixed issue #23 => DocumentHandler::deleteById() and removeById() : Para...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,28 @@
 v1.0.0 (XXXX-XX-XX)
 -------------------
 
+* issue #23: Fixed: DocumentHandler::deleteById() and removeById() : Parameter $revision should be optional.
+  Fixed bug, written missing tests and corrected documentation
+
+* issue #21: Added hiding of fields for documents. Written tests and documentation.
+  Implemented new feautre, written tests and documentation
+
+  Hiding of fields for documents:
+
+      This applies to getAll(), __toString(), toJson() and toSerialized().
+      getAll() now can be passed an array of options instead of the boolean 'includeInternals'.
+      DocumentHandler::get() and getById() can also be given those options
+
+      CollectionHandler::byExample() can also be given those options
+
+      All the above functions except the __toString can be given an array of options
+      currently these options are:
+
+      'includeInternals' - true to include the internal attributes. Defaults to false
+
+      'ignoreHiddenAttributes' - true to show hidden attributes. Defaults to false
+
+
 * issue #18: Implemented revision check with policy = "error" 
   for update/replace and delete/remove methods.
 
@@ -33,5 +55,6 @@ CollectionHandler:
 
 
 * issue #11: Written initial unit tests for api.
+
 * issue #10: Implemented api version info constant and a getVersion() method to go with it.
 

--- a/UNITTESTS.md
+++ b/UNITTESTS.md
@@ -6,16 +6,3 @@ To run the unit tests, cd into the tests folder and run:
 phpunit --testsuite ArangoDB-PHP
 </code>
 
-
-###Changelog:
-
-2012-10-06 : Some tests are failing because of issue https://github.com/triAGENS/ArangoDB/issues/220
-
-2012-10-06 : Initial Commit. This first batch covers most important parts of:
-- Connection
-- Collection
-- CollectionHandler
-- Document
-- Documenthandler
-- Statements
-

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,12 @@
   "authors": [
     {
       "name": "Jan Steemann",
-      "homepage": "https://github.com/triAGENS/ArangoDB-PHP"
+      "homepage": "https://github.com/triAGENS/ArangoDB-PHP",
+      "role": "Developer"
+    },
+    {
+      "name": "Contributors",
+      "homepage": "https://github.com/triAGENS/ArangoDB-PHP/graphs/contributors"
     }
   ],
   "require": {

--- a/docs/classes/triagens.ArangoDb.Autoloader.html
+++ b/docs/classes/triagens.ArangoDb.Autoloader.html
@@ -170,7 +170,7 @@ Arango PHP client.</p></div>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.BindVars.html
+++ b/docs/classes/triagens.ArangoDb.BindVars.html
@@ -176,7 +176,7 @@ than these types.</p></div>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.ClientException.html
+++ b/docs/classes/triagens.ArangoDb.ClientException.html
@@ -271,7 +271,7 @@ on the client side, i.e.</p>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.Collection.html
+++ b/docs/classes/triagens.ArangoDb.Collection.html
@@ -444,7 +444,7 @@ For example this must be set to 3 in order to create an edge-collection.</p></di
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.CollectionHandler.html
+++ b/docs/classes/triagens.ArangoDb.CollectionHandler.html
@@ -588,7 +588,7 @@ appropriate HTTP requests to the server.</p></div>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.ConnectException.html
+++ b/docs/classes/triagens.ArangoDb.ConnectException.html
@@ -271,7 +271,7 @@ during connecting to the server</p>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.Connection.html
+++ b/docs/classes/triagens.ArangoDb.Connection.html
@@ -403,7 +403,7 @@ will restore it.</p></div>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.ConnectionOptions.html
+++ b/docs/classes/triagens.ArangoDb.ConnectionOptions.html
@@ -416,7 +416,7 @@ It provides array access to its members.</p></div>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.Cursor.html
+++ b/docs/classes/triagens.ArangoDb.Cursor.html
@@ -395,7 +395,7 @@ results from the server</p></div>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.DefaultValues.html
+++ b/docs/classes/triagens.ArangoDb.DefaultValues.html
@@ -132,7 +132,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.Document.html
+++ b/docs/classes/triagens.ArangoDb.Document.html
@@ -569,7 +569,7 @@ To reliably store a document id elsewhere, a PHP string should be used</p></div>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.DocumentHandler.html
+++ b/docs/classes/triagens.ArangoDb.DocumentHandler.html
@@ -246,7 +246,7 @@ appropriate HTTP requests to the server.</p></div>
 <div class="subelement argument">
 <h4>$revision</h4>
 <code>mixed</code><ul>
-<li>revision of the document to be deleted</li>
+<li>optional revision of the document to be deleted</li>
 </ul>
 </div>
 <div class="subelement argument">
@@ -456,7 +456,7 @@ appropriate HTTP requests to the server.</p></div>
 <div class="subelement argument">
 <h4>$revision</h4>
 <code>mixed</code><ul>
-<li>revision of the document to be deleted</li>
+<li>optional revision of the document to be deleted</li>
 </ul>
 </div>
 <div class="subelement argument">
@@ -819,7 +819,7 @@ that the revision of the to-be-replaced document is the same as the one given.</
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.Edge.html
+++ b/docs/classes/triagens.ArangoDb.Edge.html
@@ -794,7 +794,7 @@ To reliably store a document id elsewhere, a PHP string should be used</p></div>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.EdgeHandler.html
+++ b/docs/classes/triagens.ArangoDb.EdgeHandler.html
@@ -217,7 +217,7 @@ appropriate HTTP requests to the server.</p></div>
 <div class="subelement argument">
 <h4>$revision</h4>
 <code>mixed</code><ul>
-<li>revision of the document to be deleted</li>
+<li>optional revision of the document to be deleted</li>
 </ul>
 </div>
 <div class="subelement argument">
@@ -540,7 +540,7 @@ appropriate HTTP requests to the server.</p></div>
 <div class="subelement argument">
 <h4>$revision</h4>
 <code>mixed</code><ul>
-<li>revision of the document to be deleted</li>
+<li>optional revision of the document to be deleted</li>
 </ul>
 </div>
 <div class="subelement argument">
@@ -969,7 +969,7 @@ that the revision of the to-be-replaced document is the same as the one given.</
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.Endpoint.html
+++ b/docs/classes/triagens.ArangoDb.Endpoint.html
@@ -252,7 +252,7 @@ the following endpoint types are currently supported (more to be added later):
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.Exception.html
+++ b/docs/classes/triagens.ArangoDb.Exception.html
@@ -225,7 +225,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.Handler.html
+++ b/docs/classes/triagens.ArangoDb.Handler.html
@@ -141,7 +141,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.HttpHelper.html
+++ b/docs/classes/triagens.ArangoDb.HttpHelper.html
@@ -272,7 +272,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.HttpResponse.html
+++ b/docs/classes/triagens.ArangoDb.HttpResponse.html
@@ -275,7 +275,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.Scope.html
+++ b/docs/classes/triagens.ArangoDb.Scope.html
@@ -223,7 +223,7 @@ duplicate execution of the exit func.</p></div></div></div>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.ServerException.html
+++ b/docs/classes/triagens.ArangoDb.ServerException.html
@@ -374,7 +374,7 @@ that occurred, they will be put here.</p></div>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.Statement.html
+++ b/docs/classes/triagens.ArangoDb.Statement.html
@@ -435,7 +435,7 @@ provides the additional results.</p>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.URLHelper.html
+++ b/docs/classes/triagens.ArangoDb.URLHelper.html
@@ -191,7 +191,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.URLs.html
+++ b/docs/classes/triagens.ArangoDb.URLs.html
@@ -125,7 +125,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.UpdatePolicy.html
+++ b/docs/classes/triagens.ArangoDb.UpdatePolicy.html
@@ -132,7 +132,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/classes/triagens.ArangoDb.ValueValidator.html
+++ b/docs/classes/triagens.ArangoDb.ValueValidator.html
@@ -107,7 +107,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/deprecated.html
+++ b/docs/deprecated.html
@@ -144,7 +144,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/errors.html
+++ b/docs/errors.html
@@ -96,7 +96,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/graph_class.html
+++ b/docs/graph_class.html
@@ -64,7 +64,7 @@
         </script><div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,7 +84,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/markers.html
+++ b/docs/markers.html
@@ -69,7 +69,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/namespaces/triagens.ArangoDb.html
+++ b/docs/namespaces/triagens.ArangoDb.html
@@ -276,7 +276,7 @@ server.</p>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/namespaces/triagens.html
+++ b/docs/namespaces/triagens.html
@@ -287,7 +287,7 @@ server.</p>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/packages/ArangoDbPhpClient.html
+++ b/docs/packages/ArangoDbPhpClient.html
@@ -311,7 +311,7 @@ server.</p>
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/packages/Default.html
+++ b/docs/packages/Default.html
@@ -67,7 +67,7 @@
 <div class="row"><footer class="span12">
             Template is built using <a href="http://twitter.github.com/bootstrap/">Twitter Bootstrap 2</a> and icons provided by <a href="http://glyphicons.com/">Glyphicons</a>.<br>
             Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor 2.0.0a10</a> and<br>
-            generated on 2012-11-14T08:57:00+02:00.<br></footer></div>
+            generated on 2012-11-18T00:58:44+02:00.<br></footer></div>
 </div>
 </body>
 </html>

--- a/docs/structure.xml
+++ b/docs/structure.xml
@@ -1064,7 +1064,7 @@ provides the additional results.</p>
       </method>
     </class>
   </file>
-  <file path="DocumentHandler.php" hash="e6f2c382f69a2f9d5b4415a9561acb86" package="ArangoDbPhpClient">
+  <file path="DocumentHandler.php" hash="6027541b9f1bdafe5179ee70a73cc828" package="ArangoDbPhpClient">
     <docblock line="3">
       <description><![CDATA[ArangoDB PHP client: document handler]]></description>
       <long-description><![CDATA[]]></long-description>
@@ -1585,7 +1585,7 @@ that the revision of the to-be-replaced document is the same as the one given.</
           <tag line="332" name="param" description="- document id as string or number" type="mixed" variable="$documentId">
             <type by_reference="false">mixed</type>
           </tag>
-          <tag line="332" name="param" description="- revision of the document to be deleted" type="mixed" variable="$revision">
+          <tag line="332" name="param" description="- optional revision of the document to be deleted" type="mixed" variable="$revision">
             <type by_reference="false">mixed</type>
           </tag>
           <tag line="332" name="param" description="- policy to be used in case of conflict" type="mixed" variable="$policy">
@@ -1608,7 +1608,7 @@ that the revision of the to-be-replaced document is the same as the one given.</
         </argument>
         <argument line="344">
           <name>$revision</name>
-          <default><![CDATA[]]></default>
+          <default><![CDATA[NULL]]></default>
           <type/>
         </argument>
         <argument line="344">
@@ -1632,7 +1632,7 @@ that the revision of the to-be-replaced document is the same as the one given.</
           <tag line="351" name="param" description="- document id as string or number" type="mixed" variable="$documentId">
             <type by_reference="false">mixed</type>
           </tag>
-          <tag line="351" name="param" description="- revision of the document to be deleted" type="mixed" variable="$revision">
+          <tag line="351" name="param" description="- optional revision of the document to be deleted" type="mixed" variable="$revision">
             <type by_reference="false">mixed</type>
           </tag>
           <tag line="351" name="param" description="- policy to be used in case of conflict" type="mixed" variable="$policy">
@@ -1654,7 +1654,7 @@ that the revision of the to-be-replaced document is the same as the one given.</
         </argument>
         <argument line="361">
           <name>$revision</name>
-          <default><![CDATA[]]></default>
+          <default><![CDATA[NULL]]></default>
           <type/>
         </argument>
         <argument line="361">
@@ -3794,7 +3794,7 @@ For example this must be set to 3 in order to create an edge-collection.</p>]]><
       </method>
     </class>
   </file>
-  <file path="Document.php" hash="12e93ec20988eb8c2b93f5180034092d" package="ArangoDbPhpClient">
+  <file path="Document.php" hash="051990cf5d1e4382676c08b7ccdfe33a" package="ArangoDbPhpClient">
     <docblock line="3">
       <description><![CDATA[ArangoDB PHP client: single document]]></description>
       <long-description><![CDATA[]]></long-description>

--- a/lib/triagens/ArangoDb/DocumentHandler.php
+++ b/lib/triagens/ArangoDb/DocumentHandler.php
@@ -335,13 +335,13 @@ class DocumentHandler extends Handler {
    * @throws Exception
    * @param mixed $collectionId - collection id as string or number
    * @param mixed $documentId - document id as string or number
-   * @param  mixed $revision - revision of the document to be deleted
+   * @param  mixed $revision - optional revision of the document to be deleted
    * @param mixed $policy - policy to be used in case of conflict
    * @return bool - always true, will throw if there is an error
    * 
    * @deprecated to be removed in version 2.0 - This function is being replaced by removeById()
    */
-  public function deleteById($collectionId, $documentId, $revision, $policy = NULL) {
+  public function deleteById($collectionId, $documentId, $revision = NULL, $policy = NULL) {
     $result = $this->removeById($collectionId, $documentId, $revision, $policy);
 
     return true;
@@ -354,11 +354,11 @@ class DocumentHandler extends Handler {
    * @throws Exception
    * @param mixed $collectionId - collection id as string or number
    * @param mixed $documentId - document id as string or number
-   * @param  mixed $revision - revision of the document to be deleted
+   * @param  mixed $revision - optional revision of the document to be deleted
    * @param mixed $policy - policy to be used in case of conflict
    * @return bool - always true, will throw if there is an error
    */
-  public function removeById($collectionId, $documentId, $revision, $policy = NULL) {
+  public function removeById($collectionId, $documentId, $revision = NULL, $policy = NULL) {
    if (!is_null($revision)) {
        $params[ConnectionOptions::OPTION_REVISION]=$revision;
     } 


### PR DESCRIPTION
...meter $revision should be optional

implemented missing tests for deleteById() with and without revisions and policies
- updated CHANGELOG
- updated composer.json
- updated UNITTESTS.md (CHANGELOG doesn't need to be here. It's already in the main CHANGELOG)

Signed-off-by: Frank Mayer frank@frankmayer.net
