### PR TITLE
Fixed any() for empty collections.

### DIFF
--- a/lib/triagens/ArangoDb/CollectionHandler.php
+++ b/lib/triagens/ArangoDb/CollectionHandler.php
@@ -942,7 +942,11 @@ class CollectionHandler extends
         $response = $this->getConnection()->put(Urls::URL_ANY, $this->json_encode_wrapper($data));
         $data     = $response->getJson();
 
-        return Document::createFromArray($data['document']);
+        if ($data['document']) {
+            return Document::createFromArray($data['document']);
+        } else {
+            return null;
+        }
     }
 
 

--- a/tests/CollectionExtendedTest.php
+++ b/tests/CollectionExtendedTest.php
@@ -1615,6 +1615,29 @@ class CollectionExtendedTest extends
         }
     }
 
+    /**
+     * Test getting a random document from an empty collection
+     */
+    public function testAnyDocumentInAnEmptyCollection()
+    {
+
+        $collectionHandler = $this->collectionHandler;
+
+        try {
+            $collectionHandler->delete('ArangoDB_PHP_TestSuite_TestCollection_Any_Empty');
+        } catch (Exception $e) {
+            //Ignore
+        }
+
+        $collectionHandler->create('ArangoDB_PHP_TestSuite_TestCollection_Any_Empty');
+
+        $any = $collectionHandler->any('ArangoDB_PHP_TestSuite_TestCollection_Any_Empty');
+
+        $this->assertNull($any, "any() on an empty collection should return null.");
+
+        $collectionHandler->delete('ArangoDB_PHP_TestSuite_TestCollection_Any_Empty');
+    }
+
     public function tearDown()
     {
         try {


### PR DESCRIPTION
Found this bug where an empty collection will throw an exception if we use any() on it.

This has been fix and a test has been written to test against this.
