### PR TITLE
Fixed bad encoding of empty arrays.

### DIFF
--- a/lib/triagens/ArangoDb/Connection.php
+++ b/lib/triagens/ArangoDb/Connection.php
@@ -606,7 +606,12 @@ class Connection
         if ($this->_options[ConnectionOptions::OPTION_CHECK_UTF8_CONFORM] === true) {
             self::check_encoding($data);
         }
-        $response = json_encode($data, $options);
+        
+        if(empty($data)){
+        	$response = json_encode($data, $options | JSON_FORCE_OBJECT);
+        }else{
+        	$response = json_encode($data, $options);
+        }
 
         return $response;
     }


### PR DESCRIPTION
This deals with https://github.com/triAGENS/ArangoDB/issues/495 from the ArangoDB-PHP side.

When creating a document with no data, ArangoDB-PHP sends a `[]` instead of `{}`. This causes all sorts of problems on the server.
