### PR TITLE
Fixed bug where getRegisteredAQLFunctions() was not using the namespace filter.

### DIFF
--- a/lib/triagens/ArangoDb/AqlUserFunction.php
+++ b/lib/triagens/ArangoDb/AqlUserFunction.php
@@ -120,10 +120,11 @@ class AqlUserFunction
         $attributes = $this->attributes;
 
 
-        if (is_null($name)) {
+        if ($name) {
             $attributes['name'] = $this->getName();
         }
-        if (is_null($code)) {
+
+        if ($code) {
             $attributes['code'] = $this->getCode();
         }
 
@@ -178,7 +179,7 @@ class AqlUserFunction
     public function getRegisteredUserFunctions($namespace = null)
     {
         $url = UrlHelper::buildUrl(Urls::URL_AQL_USER_FUNCTION);
-        if (is_null($namespace)) {
+        if (!is_null($namespace)) {
             $url = UrlHelper::appendParamsUrl($url, array('namespace' => $namespace));
         }
         $response = $this->_connection->get($url);

--- a/tests/AqlUserFunctionTest.php
+++ b/tests/AqlUserFunctionTest.php
@@ -73,6 +73,38 @@ class AqlUserFunctionTest extends
         );
     }
 
+    /**
+     * Test if AqlUserFunctions can be registered, listed and unregistered using the register() shortcut method
+     */
+    public function testRegisterListAndUnregisterAqlUserFunctionUsingShortcut()
+    {
+
+        $name = 'myFunctions:myFunction';
+        $code = 'function (celsius) { return celsius * 1.8 + 32; }';
+
+        $userFunction = new AqlUserFunction($this->connection);
+
+        $result = $userFunction->register($name, $code);
+
+        $this->assertTrue(
+                $result['error'] == false,
+                'result[\'error\'] Did not return false, instead returned: ' . print_r($result, 1)
+        );
+        $list = $userFunction->getRegisteredUserFunctions();
+
+        $this->assertCount(1, $list, 'List returned did not return expected 1 attribute');
+        $this->assertTrue(
+                $list[0]['name'] == $name && $list[0]['code'] == $code,
+                'did not return expected Function. Instead returned: ' . $list[0]['name'] . ' and ' . $list[0]['code']
+        );
+
+        $result = $userFunction->unregister();
+
+        $this->assertTrue(
+                $result['error'] == false,
+                'result[\'error\'] Did not return false, instead returned: ' . print_r($result, 1)
+        );
+    }
 
     /**
      * Test if AqlUserFunctions can be registered, listed and unregistered with getters and setters
@@ -223,6 +255,37 @@ class AqlUserFunctionTest extends
         );
     }
 
+    public function testGetAQLFunctionsWithNamespaceFilter()
+    {
+
+        $name1 = 'myFunctions:myFunction';
+        $name2 = 'myFunctions1:myFunction';
+        $code = 'function (celsius) { return celsius * 1.8 + 32; }';
+
+        //Setup
+        $userFunction = new AqlUserFunction($this->connection);
+
+        $userFunction->name = $name1;
+        $userFunction->code = $code;
+
+        $result = $userFunction->register();
+
+        $userFunction = new AqlUserFunction($this->connection);
+
+        $userFunction->name = $name2;
+        $userFunction->code = $code;
+
+        $result = $userFunction->register();
+
+        $functions = $userFunction->getRegisteredUserFunctions('myFunctions');
+        $this->assertCount(1, $functions, "myFunctions namespace should only contain 1 function.");
+
+        $functions = $userFunction->getRegisteredUserFunctions('myFunctions1');
+        $this->assertCount(1, $functions, "myFunctions namespace should only contain 1 function.");
+
+        $userFunction->unregister($name1);
+        $userFunction->unregister($name2);
+    }
 
     public function tearDown()
     {


### PR DESCRIPTION
A test for this has been added as well.
