### PR TITLE
Update to ArangoDB 1.3.2.

### DIFF
--- a/tests/travis/setup_arangodb.sh
+++ b/tests/travis/setup_arangodb.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
-VERSION=1.3.1
+VERSION=1.3.2
 NAME=ArangoDB-$VERSION
 
 if [ ! -d "$DIR/$NAME" ]; then


### PR DESCRIPTION
Just a small update to use 1.3.2 for our travis tests.
