### PR TITLE
* Implemented x-arango-version. Closes #160.

### DIFF
--- a/lib/triagens/ArangoDb/Connection.php
+++ b/lib/triagens/ArangoDb/Connection.php
@@ -29,7 +29,7 @@ class Connection
      *
      * @var string
      */
-    public static $_apiVersion = '1.4.0';
+    public static $_apiVersion = 10400;
 
     /**
      * Connection options
@@ -425,7 +425,7 @@ class Connection
      */
     public static function getClientVersion()
     {
-        return self::$_apiVersion;
+         return self::$_apiVersion;
     }
 
 

--- a/lib/triagens/ArangoDb/HttpHelper.php
+++ b/lib/triagens/ArangoDb/HttpHelper.php
@@ -143,9 +143,12 @@ class HttpHelper
             $connection = sprintf("Connection: %s%s", $options[ConnectionOptions::OPTION_CONNECTION], self::EOL);
         }
 
+        $apiVersion = 'x-arango-version: ' . Connection::$_apiVersion . self::EOL;
+
         // finally assemble the request
         $request = sprintf('%s %s %s%s', $method, $url, self::PROTOCOL, self::EOL) .
             $host .
+            $apiVersion .
             $contentType .
             $authorization .
             $connection .

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -65,10 +65,10 @@ class ConnectionTest extends
         $connection = getConnection();
 
         $response = $connection->getVersion();
-        $this->assertTrue($response !== "", 'Version String is empty!');
+        $this->assertTrue($response >0, 'Version number is not correct!');
 
         $response = $connection->getClientVersion();
-        $this->assertTrue($response !== "", 'Version String is empty!');
+        $this->assertTrue($response >0, 'Version number is not correct!');
     }
 
     /**


### PR DESCRIPTION
There is a minor backward incompatibility. We are now following ArangoDB's integer version numbering style.
Instead of 1.4.0 we return 10400 when calling the Connection::getVersion() / getClientVersion() method.
This has hopefully not any enormous impact. If it has please inform me so we can find a better solution...
