### PR TITLE
Use nightly builds for testing in devel.

### DIFF
--- a/tests/travis/setup_arangodb.sh
+++ b/tests/travis/setup_arangodb.sh
@@ -3,13 +3,13 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
-VERSION=2.0.0-rc1
+VERSION=devel-nightly
 NAME=ArangoDB-$VERSION
 
 if [ ! -d "$DIR/$NAME" ]; then
   # download ArangoDB
-  echo "wget http://www.arangodb.org/repositories/travisCI/$NAME.tar.gz"
-  wget http://www.arangodb.org/repositories/travisCI/$NAME.tar.gz
+  echo "wget https://www.arangodb.org/repositories/nightly/travisCI/$NAME.tar.gz"
+  wget https://www.arangodb.org/repositories/nightly/travisCI/$NAME.tar.gz
   echo "tar zxf $NAME.tar.gz"
   tar zvxf $NAME.tar.gz
 fi
@@ -19,11 +19,7 @@ PID=$(echo $PPID)
 TMP_DIR="/tmp/arangodb.$PID"
 PID_FILE="/tmp/arangodb.$PID.pid"
 ARANGODB_DIR="$DIR/$NAME"
-
-ARANGOD="${ARANGODB_DIR}/bin/arangod"
-if [ "$ARCH" == "x86_64" ]; then
-  ARANGOD="${ARANGOD}_x86_64"
-fi
+ARANGOD="${ARANGODB_DIR}/bin/arangod_x86_64"
 
 # create database directory
 mkdir ${TMP_DIR}
@@ -34,8 +30,8 @@ ${ARANGOD} \
     --database.directory ${TMP_DIR} \
     --configuration none \
     --server.endpoint tcp://127.0.0.1:8529 \
-    --javascript.startup-directory ${ARANGODB_DIR}/js \
     --javascript.app-path ${ARANGODB_DIR}/js/apps \
+    --javascript.startup-directory ${ARANGODB_DIR}/js \
     --database.maximal-journal-size 1048576 \
     --server.disable-authentication true &
 


### PR DESCRIPTION
This change switches us to the nightly devel binaries, so we can make sure the devel version of the library works against the bleeding edge most of the time.
