### PR TITLE
Fix: The edges api call didnt work anymore.

### DIFF
--- a/lib/triagens/ArangoDb/EdgeHandler.php
+++ b/lib/triagens/ArangoDb/EdgeHandler.php
@@ -204,10 +204,10 @@ class EdgeHandler extends
     {
 
         $params   = array(
-            self::OPTION_COLLECTION => $collectionId,
             self::OPTION_VERTEX     => $vertexHandle,
             self::OPTION_DIRECTION  => $direction
         );
+		$url      = UrlHelper::buildUrl(Urls::URL_EDGES, array($collectionId));
         $url      = UrlHelper::appendParamsUrl(Urls::URL_EDGE, $params);
         $response = $this->getConnection()->get($url);
         $json     = $response->getJson();

--- a/lib/triagens/ArangoDb/Urls.php
+++ b/lib/triagens/ArangoDb/Urls.php
@@ -29,6 +29,11 @@ abstract class Urls
      * URL base part for all document-related REST calls
      */
     const URL_EDGE = '/_api/edge';
+    
+	/**
+     * URL base part for all edges-related REST calls
+     */
+    const URL_EDGES = '/_api/edges';
 
     /**
      * URL base part for all document-related REST calls


### PR DESCRIPTION
I don't now whether this never worked or the api changed. I fixed it the second time so i think a pull request is appropriate. 

What it did before:
/_api/edge/?collection=<COLLECTIONID>vertex=<VERTEXID>&direction=out
but this didn't work
This is what it does now:
/_api/edges/<COLLECTIONID>?vertex=<VERTEXID>&direction=out
this works for us.