### PR TITLE
json_encode_wrapper: Let $options default to 0

### DIFF
--- a/lib/ArangoDBClient/Connection.php
+++ b/lib/ArangoDBClient/Connection.php
@@ -713,7 +713,7 @@ class Connection
      * @return string the result of the json_encode
      * @throws \ArangoDBClient\ClientException
      */
-    public function json_encode_wrapper($data, $options = null)
+    public function json_encode_wrapper($data, $options = 0)
     {
         if ($this->_options[ConnectionOptions::OPTION_CHECK_UTF8_CONFORM] === true) {
             self::check_encoding($data);


### PR DESCRIPTION
hhvm croaks on `json_encode($str, null);`, make it happy by passing 0 as default options.

The error I got (hhvm-3.18.1): `json_encode() expects parameter 2 to be integer, null given`