### PR TITLE
make byExample() and firstExample() batch'able

### DIFF
--- a/lib/ArangoDBClient/BatchPart.php
+++ b/lib/ArangoDBClient/BatchPart.php
@@ -246,6 +246,16 @@ class BatchPart
 
         $response = $this->getResponse();
         switch ($this->_type) {
+            case 'first':
+                $json             = $response->getJson();
+                if (!isset($json['error']) || $json['error'] === false) {
+                    $options          = $this->getCursorOptions();
+                    $options['isNew'] = false;
+                    $response         = $_documentClass::createFromArray($json['document'], $options);
+                } else {
+                    $response         = false;
+                }
+                break;
             case 'getdocument':
                 $json             = $response->getJson();
                 $options          = $this->getCursorOptions();
@@ -284,6 +294,7 @@ class BatchPart
                 }
                 break;
             case 'cursor':
+            case 'by':
                 $options          = $this->getCursorOptions();
                 $options['isNew'] = false;
 

--- a/lib/ArangoDBClient/BatchPart.php
+++ b/lib/ArangoDBClient/BatchPart.php
@@ -249,11 +249,11 @@ class BatchPart
             case 'first':
                 $json             = $response->getJson();
                 if (!isset($json['error']) || $json['error'] === false) {
-                    $options          = $this->getCursorOptions();
-                    $options['isNew'] = false;
-                    $response         = $_documentClass::createFromArray($json['document'], $options);
+                    $options           = $this->getCursorOptions();
+                    $options['_isNew'] = false;
+                    $response          = $_documentClass::createFromArray($json['document'], $options);
                 } else {
-                    $response         = false;
+                    $response          = false;
                 }
                 break;
             case 'getdocument':

--- a/lib/ArangoDBClient/CollectionHandler.php
+++ b/lib/ArangoDBClient/CollectionHandler.php
@@ -1251,6 +1251,10 @@ class CollectionHandler extends Handler
 
         $response = $this->getConnection()->put(Urls::URL_EXAMPLE, $this->json_encode_wrapper($body));
 
+        if ($batchPart = $response->getBatchPart()) {
+            return $batchPart;
+        }
+
         $options['isNew'] = false;
 
         $options = array_merge(['_documentClass' => $this->_documentClass], $options);
@@ -1301,6 +1305,11 @@ class CollectionHandler extends Handler
         ];
 
         $response = $this->getConnection()->put(Urls::URL_FIRST_EXAMPLE, $this->json_encode_wrapper($data));
+        
+        if ($batchPart = $response->getBatchPart()) {
+            return $batchPart;
+        }
+        
         $data     = $response->getJson();
 
         $options['_isNew'] = false;


### PR DESCRIPTION
It seems to me that byExample could be used in batch very well, but I'm unsure how to handle "nothing found" of firstExample()