### PR TITLE
Fixed exception with multiple calls to validate method

### DIFF
--- a/lib/ArangoDBClient/ConnectionOptions.php
+++ b/lib/ArangoDBClient/ConnectionOptions.php
@@ -375,6 +375,7 @@ class ConnectionOptions implements \ArrayAccess
             if (isset($this->_values[self::OPTION_HOST]) && !isset($this->_values[self::OPTION_ENDPOINT])) {
                 // upgrade host/port to an endpoint
                 $this->_values[self::OPTION_ENDPOINT] = 'tcp://' . $this->_values[self::OPTION_HOST] . ':' . $this->_values[self::OPTION_PORT];
+                unset($this->_values[self::OPTION_HOST]);
             }
         }
 


### PR DESCRIPTION
Sometimes ConnectionOptions::validate() is called multiple times during ConnectionOptions lifetime cycle, which may trigger "must not specify both host and endpoint" exception when originally there was only host and port provided.
