### PR TITLE
SetDocumentClass fluid interface

### DIFF
--- a/lib/ArangoDBClient/Batch.php
+++ b/lib/ArangoDBClient/Batch.php
@@ -569,10 +569,12 @@ class Batch
      * Sets the document class to use
      *
      * @param string $class Document class to use
+     * @return Batch
      */
     public function setDocumentClass($class)
     {
         $this->_documentClass = $class;
+        return $this;
     }
 }
 

--- a/lib/ArangoDBClient/BatchPart.php
+++ b/lib/ArangoDBClient/BatchPart.php
@@ -347,10 +347,12 @@ class BatchPart
      * Sets the document class to use
      *
      * @param string $class Document class to use
+     * @return BatchPart
      */
     public function setDocumentClass($class)
     {
         $this->_documentClass = $class;
+        return $this;
     }
 }
 

--- a/lib/ArangoDBClient/Cursor.php
+++ b/lib/ArangoDBClient/Cursor.php
@@ -836,10 +836,12 @@ class Cursor implements \Iterator
      * Sets the document class to use
      *
      * @param string $class Document class to use
+     * @return Cursor
      */
     public function setDocumentClass($class)
     {
         $this->_documentClass = $class;
+        return $this;
     }
 }
 

--- a/lib/ArangoDBClient/Export.php
+++ b/lib/ArangoDBClient/Export.php
@@ -274,10 +274,12 @@ class Export
      * Sets the document class to use
      *
      * @param string $class Document class to use
+     * @return Export
      */
     public function setDocumentClass($class)
     {
         $this->_documentClass = $class;
+        return $this;
     }
 }
 

--- a/lib/ArangoDBClient/ExportCursor.php
+++ b/lib/ArangoDBClient/ExportCursor.php
@@ -290,10 +290,12 @@ class ExportCursor
      * Sets the document class to use
      *
      * @param string $class Document class to use
+     * @return ExportCursor
      */
     public function setDocumentClass($class)
     {
         $this->_documentClass = $class;
+        return $this;
     }
 }
 

--- a/lib/ArangoDBClient/Handler.php
+++ b/lib/ArangoDBClient/Handler.php
@@ -166,10 +166,12 @@ abstract class Handler
      * Sets the document class to use
      *
      * @param string $class Document class to use
+     * @return Handler
      */
     public function setDocumentClass($class)
     {
         $this->_documentClass = $class;
+        return $this;
     }
 
 }

--- a/lib/ArangoDBClient/Statement.php
+++ b/lib/ArangoDBClient/Statement.php
@@ -558,10 +558,12 @@ class Statement
      * Sets the document class to use
      *
      * @param string $class Document class to use
+     * @return Statement
      */
     public function setDocumentClass($class)
     {
         $this->_documentClass = $class;
+        return $this;
     }
 }
 


### PR DESCRIPTION
Small addition to https://github.com/arangodb/arangodb-php/pull/208 - it allows to use fluid calls like:

```php
$statement->setDocumentClass('\appBundle\Entity\CustomDocument')->execute();
```