### PR TITLE
add automatic failover to driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
+Release notes for the ArangoDB-PHP driver 3.3.x
+===============================================
+
+Starting from release 3.3.1, the PHP driver has support for automatic failover, for
+ArangoDB servers that are started in the "resilient single" or active/passive failover
+mode. This setup requires using ArangoDB 3.3.
+
+In order to use automatic failover from the PHP driver, simply change the "endpoint"
+attribute of the connection options from a simple endpoint string into an array of
+endpoint strings:
+    
+    $connectionOptions = [
+        ConnectionOptions::OPTION_ENDPOINT    => [ 'tcp://localhost:8531', 'tcp://localhost:8532', 'tcp://localhost:8530' ],  // endpoints to connect to
+        ...
+    ];
+    $connection = new Connection($connectionOptions);
+
+instead of just
+    
+    $connectionOptions = [
+        ConnectionOptions::OPTION_ENDPOINT    => 'tcp://localhost:8530',  // endpoint to connect to
+        ...
+    ];
+    $connection = new Connection($connectionOptions);
+
+
 Release notes for the ArangoDB-PHP driver 3.2.0
 ===============================================
+
 - the default value for the authentication type of the `Connection` class is now `Basic`
 
 - the default value for the connection type is now `Keep-Alive` and not `Close`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@ Release notes for the ArangoDB-PHP driver 3.3.x
 ===============================================
 
 Starting from release 3.3.1, the PHP driver has support for automatic failover, for
-ArangoDB servers that are started in the "resilient single" or active/passive failover
-mode. This setup requires using ArangoDB 3.3.
+ArangoDB servers that are started in the active failover mode. This setup requires 
+using ArangoDB 3.3.
 
 In order to use automatic failover from the PHP driver, simply change the "endpoint"
 attribute of the connection options from a simple endpoint string into an array of
 endpoint strings:
     
     $connectionOptions = [
-        ConnectionOptions::OPTION_ENDPOINT    => [ 'tcp://localhost:8531', 'tcp://localhost:8532', 'tcp://localhost:8530' ],  // endpoints to connect to
+        ConnectionOptions::OPTION_ENDPOINT => [ 'tcp://localhost:8531', 'tcp://localhost:8532', 'tcp://localhost:8530' ],
         ...
     ];
     $connection = new Connection($connectionOptions);
@@ -18,13 +18,40 @@ endpoint strings:
 instead of just
     
     $connectionOptions = [
-        ConnectionOptions::OPTION_ENDPOINT    => 'tcp://localhost:8530',  // endpoint to connect to
+        ConnectionOptions::OPTION_ENDPOINT => 'tcp://localhost:8530',
         ...
     ];
     $connection = new Connection($connectionOptions);
 
 
-Release notes for the ArangoDB-PHP driver 3.2.0
+Additionally, retrieving the endpoint value of `ConnectionOptions` will now always 
+return an array of endpoints. For the single-server case, the returned value will be
+an array with the specified endpoint. When active failover is used, the result will
+be an array with the specified endpoints or the endpoints found (added) at runtime.
+For example, in
+ 
+    $options = [ ConnectionOptions::OPTION_ENDPOINT => 'tcp://127.0.0.1:8529' ];
+    $co = new ConnectionOptions($options);
+    print_r($co[ConnectionOptions::OPTION_ENDPOINT]);
+
+This will now print an array (`[ 'tcp://127.0.0.1:8529' ]`) and not just the string
+(`tcp://127.0.0.1:8529'). Client applications that retrieve the endpoint value via
+the `ConnectionOptions` object and expect it to be a string should be adjusted to 
+pick the first value from the now-returned result array instead.
+
+Using the port option for setting up `ConnectionOptions` and reading it back is now 
+deprecated and will not be useful when using different endpoints with different port
+numbers.
+
+For example, reading the `port` option here will provide just one of the specified
+ports, so it should be avoided:
+    
+    $options = [ ConnectionOptions::OPTION_ENDPOINT => [ 'tcp://127.0.0.1:8529', 'tcp://127.0.0.1:8530' ] ];
+    $co = new ConnectionOptions($options);
+    print_r($co[ConnectionOptions::OPTION_PORT]);
+
+
+Release notes for the ArangoDB-PHP driver 3.2.x
 ===============================================
 
 - the default value for the authentication type of the `Connection` class is now `Basic`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
  - [Cloning the git repository](#cloning_git)
 - [How to use the PHP client](#howto_use)
  - [Setting up the connection options](#setting_up_connection_options)
+ - [Setting up failover](#setting_up_failover)
  - [Creating a collection](#creating_collection)
  - [Creating a document](#creating_document)
  - [Adding exception handling](#adding_exception_handling)
@@ -202,6 +203,65 @@ When updating a document that was previously/concurrently updated by another use
 
 * last update wins: if you prefer this, set OPTION_UPDATE_POLICY to last
 * fail with a conflict error: if you prefer that, set OPTION_UPDATE_POLICY to conflict
+
+
+<a name="setting_up_failover"></a>
+## Setting up failover
+
+By default the PHP client will connect to a single endpoint only,
+by specifying a string value for the endpoint in the `ConnectionOptions`, 
+e.g.
+
+```php
+$connectionOptions = [
+    ArangoConnectionOptions::OPTION_ENDPOINT => 'tcp://127.0.0.1:8529'
+];
+```
+
+To set up multiple servers to connect to, it is also possible to specify 
+an array of servers instead:
+
+```php
+$connectionOptions = [
+    ConnectionOptions::OPTION_ENDPOINT    => [ 'tcp://localhost:8531', 'tcp://localhost:8532', 'tcp://localhost:8530' ]
+];
+```
+Using this option requires ArangoDB 3.3 or higher and the database running 
+in active/passive failover mode.
+
+The driver will by default try to connect to the first server endpoint in the
+endpoints array, and only try the following servers if no connection can be
+established. If no connection can be made to any server, the driver will throw
+an exception.
+
+As it is unknown to the driver which server from the array is the current
+leader, the driver will connect to the specified servers in array order by
+default. However, to spare a few unnecessary connection attempts to failed
+servers, it is possible to set up caching (using Memcached) for the server list.
+The cached value will contain the last working server first, so that as few
+connection attempts as possible will need to be made.
+
+In order to use this caching, it is required to install the Memcached module 
+for PHP, and to set up the following relevant options in the `ConnectionOptions`:
+
+```php
+$connectionOptions = [
+    // memcached persistent id (will be passed to Memcached::__construct)
+    ConnectionOptions::OPTION_MEMCACHED_PERSISTENT_ID => 'arangodb-php-pool',
+
+    // memcached servers to connect to (will be passed to Memcached::addServers)
+    ConnectionOptions::OPTION_MEMCACHED_SERVERS       => [ [ '127.0.0.1', 11211 ] ],
+
+    // memcached options (will be passed to Memcached::setOptions)
+    ConnectionOptions::OPTION_MEMCACHED_OPTIONS       => [ ],
+
+    // key to store the current endpoints array under
+    ConnectionOptions::OPTION_MEMCACHED_ENDPOINTS_KEY => 'arangodb-php-endpoints'
+
+    // time-to-live for the endpoints array stored in memcached
+    ConnectionOptions::OPTION_MEMCACHED_TTL           => 600
+];
+```
 
 
 <a name="creating_collection"></a>

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ When updating a document that was previously/concurrently updated by another use
 
 
 <a name="setting_up_failover"></a>
-## Setting up failover
+## Setting up active failover
 
 By default the PHP client will connect to a single endpoint only,
 by specifying a string value for the endpoint in the `ConnectionOptions`, 
@@ -227,7 +227,7 @@ $connectionOptions = [
 ];
 ```
 Using this option requires ArangoDB 3.3 or higher and the database running 
-in active/passive failover mode.
+in active failover mode.
 
 The driver will by default try to connect to the first server endpoint in the
 endpoints array, and only try the following servers if no connection can be

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "arangodb/arangodb",
   "type": "library",
-  "description": "ArangoDb PHP client",
-  "keywords": ["database","ArangoDb","Arango","document store","NoSQL","multi-model","graph database"],
+  "description": "ArangoDB PHP client",
+  "keywords": ["database","ArangoDB","Arango","document store","NoSQL","multi-model","graph database","distributed"],
   "homepage": "https://github.com/arangodb/arangodb-php",
   "license": "Apache-2.0",
   "authors": [

--- a/examples/init.php
+++ b/examples/init.php
@@ -16,6 +16,23 @@ $connectionOptions = [
 
     // normal unencrypted connection via TCP/IP
     ConnectionOptions::OPTION_ENDPOINT => 'tcp://localhost:8529',  // endpoint to connect to
+    
+    // // to use failover (requires ArangoDB 3.3 and the database running in active/passive failover mode)
+    // // it is possible to specify an array of endpoints as follows:
+    // ConnectionOptions::OPTION_ENDPOINT    => [ 'tcp://localhost:8531', 'tcp://localhost:8532' ]
+    
+    // // to use memcached for caching the currently active leader (to spare a few connection attempts
+    // // to followers), it is possible to install the Memcached module for PHP and set the following options:
+    // // memcached persistent id (will be passed to Memcached::__construct)
+    // ConnectionOptions::OPTION_MEMCACHED_PERSISTENT_ID => 'arangodb-php-pool',
+    // // memcached servers to connect to (will be passed to Memcached::addServers)
+    // ConnectionOptions::OPTION_MEMCACHED_SERVERS       => [ [ '127.0.0.1', 11211 ] ],
+    // // memcached options (will be passed to Memcached::setOptions)
+    // ConnectionOptions::OPTION_MEMCACHED_OPTIONS       => [ ],
+    // // key to store the current endpoints array under
+    // ConnectionOptions::OPTION_MEMCACHED_ENDPOINTS_KEY => 'arangodb-php-endpoints'
+    // // time-to-live for the endpoints array stored in memcached
+    // ConnectionOptions::OPTION_MEMCACHED_TTL           => 600
 
     // // connection via SSL
     // ConnectionOptions::OPTION_ENDPOINT        => 'ssl://localhost:8529',  // SSL endpoint to connect to

--- a/lib/ArangoDBClient/Connection.php
+++ b/lib/ArangoDBClient/Connection.php
@@ -622,7 +622,6 @@ class Connection
                         if ($leader) {
                             // have a different leader
                             $leader = Endpoint::normalize($leader);
-
                             $this->_options->addEndpoint($leader);
                             
                         } else {

--- a/lib/ArangoDBClient/Connection.php
+++ b/lib/ArangoDBClient/Connection.php
@@ -206,7 +206,7 @@ class Connection
      */
     public function get($url, array $customHeaders = [])
     {
-        return $this->handleFailover(function() use (&$url, &$customHeaders) {
+        return $this->handleFailover(function() use ($url, $customHeaders) {
             $response = $this->executeRequest(HttpHelper::METHOD_GET, $url, '', $customHeaders);
 
             return $this->parseResponse($response);
@@ -226,7 +226,7 @@ class Connection
      */
     public function post($url, $data, array $customHeaders = [])
     {
-        return $this->handleFailover(function() use (&$url, &$data, &$customHeaders) {
+        return $this->handleFailover(function() use ($url, $data, $customHeaders) {
             $response = $this->executeRequest(HttpHelper::METHOD_POST, $url, $data, $customHeaders);
 
             return $this->parseResponse($response);
@@ -246,7 +246,7 @@ class Connection
      */
     public function put($url, $data, array $customHeaders = [])
     {
-        return $this->handleFailover(function() use (&$url, &$data, &$customHeaders) {
+        return $this->handleFailover(function() use ($url, $data, $customHeaders) {
             $response = $this->executeRequest(HttpHelper::METHOD_PUT, $url, $data, $customHeaders);
 
             return $this->parseResponse($response);
@@ -265,7 +265,7 @@ class Connection
      */
     public function head($url, array $customHeaders = [])
     {
-        return $this->handleFailover(function() use (&$url, &$customHeaders) {
+        return $this->handleFailover(function() use ($url, $customHeaders) {
             $response = $this->executeRequest(HttpHelper::METHOD_HEAD, $url, '', $customHeaders);
 
             return $this->parseResponse($response);
@@ -285,7 +285,7 @@ class Connection
      */
     public function patch($url, $data, array $customHeaders = [])
     { 
-        return $this->handleFailover(function() use (&$url, &$data, &$customHeaders) {
+        return $this->handleFailover(function() use ($url, $data, $customHeaders) {
             $response = $this->executeRequest(HttpHelper::METHOD_PATCH, $url, $data, $customHeaders);
 
             return $this->parseResponse($response);
@@ -305,7 +305,7 @@ class Connection
      */
     public function delete($url, array $customHeaders = [], $data = '')
     {
-        return $this->handleFailover(function() use (&$url, &$customHeaders, $data) {
+        return $this->handleFailover(function() use ($url, $customHeaders, $data) {
             $response = $this->executeRequest(HttpHelper::METHOD_DELETE, $url, $data, $customHeaders);
 
             return $this->parseResponse($response);
@@ -455,7 +455,7 @@ class Connection
           if ($this->_handle && is_resource($this->_handle)) {
               @fclose($this->_handle);
           }
-          $this->_handle = 0;
+          $this->_handle = null;
      }
 
     /**
@@ -528,7 +528,7 @@ class Connection
         // open the socket. note: this might throw if the connection cannot be established
         $handle = $this->getHandle();
 
-        if ($handle) {
+        if ($handle !== null) {
             // send data and get response back
 
             if ($traceFunc) {

--- a/lib/ArangoDBClient/Connection.php
+++ b/lib/ArangoDBClient/Connection.php
@@ -265,7 +265,7 @@ class Connection
      */
     public function head($url, array $customHeaders = [])
     {
-        return $this->handleFailover(function() use (&$url, &$data, &$customHeaders) {
+        return $this->handleFailover(function() use (&$url, &$customHeaders) {
             $response = $this->executeRequest(HttpHelper::METHOD_HEAD, $url, '', $customHeaders);
 
             return $this->parseResponse($response);
@@ -305,7 +305,7 @@ class Connection
      */
     public function delete($url, array $customHeaders = [], $data = '')
     {
-        return $this->handleFailover(function() use (&$url, &$data) {
+        return $this->handleFailover(function() use (&$url, &$customHeaders, $data) {
             $response = $this->executeRequest(HttpHelper::METHOD_DELETE, $url, $data, $customHeaders);
 
             return $this->parseResponse($response);

--- a/lib/ArangoDBClient/ConnectionOptions.php
+++ b/lib/ArangoDBClient/ConnectionOptions.php
@@ -31,13 +31,6 @@ class ConnectionOptions implements \ArrayAccess
     private $_values = [];
 
     /**
-     * The connection endpoint object
-     *
-     * @var Endpoint
-     */
-    private $_endpoint;
-    
-    /**
      * The index into the endpoints array that we will connect to (or are currently
      * connected to). This index will be increased in case the currently connected
      * server tells us there is a different leader. We will then simply connect
@@ -48,6 +41,13 @@ class ConnectionOptions implements \ArrayAccess
      * @var int
      */
     private $_currentEndpointIndex = 0;
+
+    /**
+     * Optional Memcached instance for endpoints caching
+     *
+     * @var Memcached
+     */
+    private $_cache = null;
 
     /**
      * Endpoint string index constant
@@ -208,10 +208,34 @@ class ConnectionOptions implements \ArrayAccess
      * UTF-8 CHeck Flag
      */
     const OPTION_CHECK_UTF8_CONFORM = 'CheckUtf8Conform';
+            
+    /**
+     * Entry for memcached servers array
+     */
+    const OPTION_MEMCACHED_SERVERS = 'memcachedServers';
+    
+    /**
+     * Entry for memcached options array
+     */
+    const OPTION_MEMCACHED_OPTIONS = 'memcachedOptions';
+    
+    /**
+     * Entry for memcached endpoints key
+     */
+    const OPTION_MEMCACHED_ENDPOINTS_KEY = 'memcachedEndpointsKey';
+    
+    /**
+     * Entry for memcached persistend id
+     */
+    const OPTION_MEMCACHED_PERSISTENT_ID = 'memcachedPersistentId';
+    
+    /**
+     * Entry for memcached cache ttl
+     */
+    const OPTION_MEMCACHED_TTL = 'memcachedTtl';
 
     /**
      * Set defaults, use options provided by client and validate them
-     *
      *
      * @param array $options - initial options
      *
@@ -220,6 +244,7 @@ class ConnectionOptions implements \ArrayAccess
     public function __construct(array $options)
     {
         $this->_values = array_merge(self::getDefaults(), $options);
+        $this->loadOptionsFromCache();
         $this->validate();
     }
 
@@ -295,22 +320,6 @@ class ConnectionOptions implements \ArrayAccess
     }
 
     /**
-     * Get the endpoint object for the connection
-     *
-     * @throws ClientException
-     * @return Endpoint - endpoint object
-     */
-    public function getEndpoint()
-    {
-        if ($this->_endpoint === null) {
-            // will also validate the endpoint
-            $this->_endpoint = new Endpoint($this->getCurrentEndpoint());
-        }
-
-        return $this->_endpoint;
-    }
-    
-    /**
      * Get the current endpoint to use
      *
      * @return string - Endpoint string to connect to
@@ -344,6 +353,10 @@ class ConnectionOptions implements \ArrayAccess
      */
     public function addEndpoint($endpoint) 
     {
+        if (!is_string($endpoint) || !Endpoint::isValid($endpoint)) {
+            throw new ClientException(sprintf("invalid endpoint specification '%s'", $endpoint));
+        }
+
         // can only add an endpoint here if the list of endpoints is already an array
         if (!is_array($this->_values[self::OPTION_ENDPOINT])) {
             // make it an array now
@@ -358,26 +371,37 @@ class ConnectionOptions implements \ArrayAccess
             // we have already got this endpoint
             $this->_currentEndpointIndex = $found;
         }
+
+        $this->storeOptionsInCache();
     }
                             
     /**
      * Return the next endpoint from the list of endpoints
+     * As a side-effect this function switches to a new endpoint
      *
      * @return string - the next endpoint
      */
     public function nextEndpoint() 
     {
-        if (!is_array($this->_values[self::OPTION_ENDPOINT])) {
-            return $this->_values[self::OPTION_ENDPOINT];
+        $endpoints = $this->_values[self::OPTION_ENDPOINT];
+        if (!is_array($endpoints)) {
+            return $endpoints;
         }
 
-        $numberOfEndpoints = count($this->_values[self::OPTION_ENDPOINT]);
+        $numberOfEndpoints = count($endpoints);
+
         $this->_currentEndpointIndex++;
         if ($this->_currentEndpointIndex >= $numberOfEndpoints) {
             $this->_currentEndpointIndex = 0;
         }
 
-        return $this->_values[self::OPTION_ENDPOINT][$this->_currentEndpointIndex];
+        $endpoint =  $endpoints[$this->_currentEndpointIndex];
+
+        if ($numberOfEndpoints > 1) {
+            $this->storeOptionsInCache();
+        }
+       
+        return $endpoint;
     }
 
     /**
@@ -388,35 +412,39 @@ class ConnectionOptions implements \ArrayAccess
     private static function getDefaults()
     {
         return [
-            self::OPTION_ENDPOINT           => null,
-            self::OPTION_HOST               => null,
-            self::OPTION_PORT               => DefaultValues::DEFAULT_PORT,
-            self::OPTION_FAILOVER_TRIES     => DefaultValues::DEFAULT_FAILOVER_TRIES,
-            self::OPTION_TIMEOUT            => DefaultValues::DEFAULT_TIMEOUT,
-            self::OPTION_CREATE             => DefaultValues::DEFAULT_CREATE,
-            self::OPTION_UPDATE_POLICY      => DefaultValues::DEFAULT_UPDATE_POLICY,
-            self::OPTION_REPLACE_POLICY     => DefaultValues::DEFAULT_REPLACE_POLICY,
-            self::OPTION_DELETE_POLICY      => DefaultValues::DEFAULT_DELETE_POLICY,
-            self::OPTION_REVISION           => null,
-            self::OPTION_WAIT_SYNC          => DefaultValues::DEFAULT_WAIT_SYNC,
-            self::OPTION_BATCHSIZE          => null,
-            self::OPTION_JOURNAL_SIZE       => DefaultValues::DEFAULT_JOURNAL_SIZE,
-            self::OPTION_IS_SYSTEM          => false,
-            self::OPTION_IS_VOLATILE        => DefaultValues::DEFAULT_IS_VOLATILE,
-            self::OPTION_CONNECTION         => DefaultValues::DEFAULT_CONNECTION,
-            self::OPTION_TRACE              => null,
-            self::OPTION_ENHANCED_TRACE     => false,
-            self::OPTION_VERIFY_CERT        => DefaultValues::DEFAULT_VERIFY_CERT,
-            self::OPTION_ALLOW_SELF_SIGNED  => DefaultValues::DEFAULT_ALLOW_SELF_SIGNED,
-            self::OPTION_CIPHERS            => DefaultValues::DEFAULT_CIPHERS,
-            self::OPTION_AUTH_USER          => null,
-            self::OPTION_AUTH_PASSWD        => null,
-            self::OPTION_AUTH_TYPE          => DefaultValues::DEFAULT_AUTH_TYPE,
-            self::OPTION_RECONNECT          => false,
-            self::OPTION_BATCH              => false,
-            self::OPTION_BATCHPART          => false,
-            self::OPTION_DATABASE           => '_system',
-            self::OPTION_CHECK_UTF8_CONFORM => DefaultValues::DEFAULT_CHECK_UTF8_CONFORM
+            self::OPTION_ENDPOINT                => null,
+            self::OPTION_HOST                    => null,
+            self::OPTION_PORT                    => DefaultValues::DEFAULT_PORT,
+            self::OPTION_FAILOVER_TRIES          => DefaultValues::DEFAULT_FAILOVER_TRIES,
+            self::OPTION_TIMEOUT                 => DefaultValues::DEFAULT_TIMEOUT,
+            self::OPTION_MEMCACHED_PERSISTENT_ID => 'arangodb-php-pool',
+            self::OPTION_MEMCACHED_OPTIONS       => [ ],
+            self::OPTION_MEMCACHED_ENDPOINTS_KEY => 'arangodb-php-endpoints',
+            self::OPTION_MEMCACHED_TTL           => 600,
+            self::OPTION_CREATE                  => DefaultValues::DEFAULT_CREATE,
+            self::OPTION_UPDATE_POLICY           => DefaultValues::DEFAULT_UPDATE_POLICY,
+            self::OPTION_REPLACE_POLICY          => DefaultValues::DEFAULT_REPLACE_POLICY,
+            self::OPTION_DELETE_POLICY           => DefaultValues::DEFAULT_DELETE_POLICY,
+            self::OPTION_REVISION                => null,
+            self::OPTION_WAIT_SYNC               => DefaultValues::DEFAULT_WAIT_SYNC,
+            self::OPTION_BATCHSIZE               => null,
+            self::OPTION_JOURNAL_SIZE            => DefaultValues::DEFAULT_JOURNAL_SIZE,
+            self::OPTION_IS_SYSTEM               => false,
+            self::OPTION_IS_VOLATILE             => DefaultValues::DEFAULT_IS_VOLATILE,
+            self::OPTION_CONNECTION              => DefaultValues::DEFAULT_CONNECTION,
+            self::OPTION_TRACE                   => null,
+            self::OPTION_ENHANCED_TRACE          => false,
+            self::OPTION_VERIFY_CERT             => DefaultValues::DEFAULT_VERIFY_CERT,
+            self::OPTION_ALLOW_SELF_SIGNED       => DefaultValues::DEFAULT_ALLOW_SELF_SIGNED,
+            self::OPTION_CIPHERS                 => DefaultValues::DEFAULT_CIPHERS,
+            self::OPTION_AUTH_USER               => null,
+            self::OPTION_AUTH_PASSWD             => null,
+            self::OPTION_AUTH_TYPE               => DefaultValues::DEFAULT_AUTH_TYPE,
+            self::OPTION_RECONNECT               => false,
+            self::OPTION_BATCH                   => false,
+            self::OPTION_BATCHPART               => false,
+            self::OPTION_DATABASE                => '_system',
+            self::OPTION_CHECK_UTF8_CONFORM      => DefaultValues::DEFAULT_CHECK_UTF8_CONFORM
         ];
     }
 
@@ -467,10 +495,12 @@ class ConnectionOptions implements \ArrayAccess
             unset($this->_values[self::OPTION_HOST]);
         }
 
-        // set up a new endpoint, this will also validate it
-        $this->getEndpoint();
-
+        // validate endpoint
         $ep = $this->getCurrentEndpoint();
+        if (!Endpoint::isValid($ep)) {
+            throw new ClientException(sprintf("invalid endpoint specification '%s'", $ep));
+        }
+
         $type = Endpoint::getType($ep);
         if ($type === Endpoint::TYPE_UNIX) {
             // must set port to 0 for UNIX domain sockets
@@ -515,6 +545,98 @@ class ConnectionOptions implements \ArrayAccess
         UpdatePolicy::validate($this->_values[self::OPTION_UPDATE_POLICY]);
         UpdatePolicy::validate($this->_values[self::OPTION_REPLACE_POLICY]);
         UpdatePolicy::validate($this->_values[self::OPTION_DELETE_POLICY]);
+    }
+
+
+    /**
+     * load and merge connection options from optional Memcached cache into
+     * ihe current settings
+     *
+     * @return void
+     */
+    private function loadOptionsFromCache() 
+    {
+        $cache = $this->getEndpointsCache();
+
+        if ($cache === null) {
+            return;
+        }
+
+        $endpoints = $cache->get($this->_values[self::OPTION_MEMCACHED_ENDPOINTS_KEY]);
+        if ($endpoints) {
+            $this->_values[self::OPTION_ENDPOINT] = $endpoints;
+        }
+    }
+    
+    /**
+     * store the updated options in the optional Memcached cache
+     *
+     * @return void
+     */
+    private function storeOptionsInCache() 
+    {
+        $endpoints = $this->_values[self::OPTION_ENDPOINT];
+        $numberOfEndpoints = count($endpoints);
+
+        if ($numberOfEndpoints <= 1) {
+            return;
+        }
+
+        // now try to store the updated values in the cache
+        $cache = $this->getEndpointsCache();
+        if ($cache === null) {
+            return;
+        }
+        
+        $update = [ $endpoints[$this->_currentEndpointIndex] ];
+        for ($i = 0; $i < $numberOfEndpoints; ++$i) {
+            if ($i !== $this->_currentEndpointIndex) {
+                $update[] = $endpoints[$i];
+            }
+        }
+
+        $ttl = (int) $this->_values[self::OPTION_MEMCACHED_TTL];
+        $cache->set($this->_values[self::OPTION_MEMCACHED_ENDPOINTS_KEY], $update, $ttl);
+      }
+
+    /**
+     * Initialize and return a memcached cache instance, 
+     * if option "memcachedServers" is set
+     *
+     * @return Memcached - memcached server instance if configured or null if not
+     */
+    private function getEndpointsCache() 
+    {
+        if ($this->_cache === null) {
+            if (!isset($this->_values[self::OPTION_MEMCACHED_SERVERS])) {
+                return null;
+            }
+            if (!class_exists('Memcached', false)) {
+                return null;
+            }
+
+            $servers = $this->_values[self::OPTION_MEMCACHED_SERVERS];
+            if (!is_array($servers)) {
+                throw new ClientException('Invalid memcached servers list. should be an array of servers');
+            }
+
+            $cache = new \Memcached(self::OPTION_MEMCACHED_PERSISTENT_ID);
+            if (empty($cache->getServerList())) {
+                $cache->addServers($servers);
+            }
+            
+            if (isset($this->_values[self::OPTION_MEMCACHED_OPTIONS])) {
+                $options = $this->_values[self::OPTION_MEMCACHED_OPTIONS];
+                if (!is_array($options)) {
+                    throw new ClientException('Invalid memcached options list. should be an array of options');
+                }
+                $cache->setOptions($options);
+            }
+
+            $this->_cache = $cache;
+        
+        }
+        return $this->_cache;
     }
 }
 

--- a/lib/ArangoDBClient/ConnectionOptions.php
+++ b/lib/ArangoDBClient/ConnectionOptions.php
@@ -56,6 +56,11 @@ class ConnectionOptions implements \ArrayAccess
      * Timeout value index constant
      */
     const OPTION_TIMEOUT = 'timeout';
+    
+    /**
+     * Number of tries for failover constant
+     */
+    const OPTION_FAILOVER_TRIES = 'failoverTries';
 
     /**
      * Trace function index constant
@@ -304,6 +309,7 @@ class ConnectionOptions implements \ArrayAccess
             self::OPTION_ENDPOINT           => null,
             self::OPTION_HOST               => null,
             self::OPTION_PORT               => DefaultValues::DEFAULT_PORT,
+            self::OPTION_FAILOVER_TRIES     => DefaultValues::DEFAULT_FAILOVER_TRIES,
             self::OPTION_TIMEOUT            => DefaultValues::DEFAULT_TIMEOUT,
             self::OPTION_CREATE             => DefaultValues::DEFAULT_CREATE,
             self::OPTION_UPDATE_POLICY      => DefaultValues::DEFAULT_UPDATE_POLICY,

--- a/lib/ArangoDBClient/DefaultValues.php
+++ b/lib/ArangoDBClient/DefaultValues.php
@@ -31,6 +31,11 @@ abstract class DefaultValues
     const DEFAULT_TIMEOUT = 30;
     
     /**
+     * Default number of failover tries (used in case there is an automatic failover)
+     */
+    const DEFAULT_FAILOVER_TRIES = 2;
+    
+    /**
      * Default Authorization type (use HTTP basic authentication)
      */
     const DEFAULT_AUTH_TYPE = 'Basic';

--- a/lib/ArangoDBClient/Endpoint.php
+++ b/lib/ArangoDBClient/Endpoint.php
@@ -167,19 +167,31 @@ class Endpoint
     /**
      * check whether an endpoint specification is valid
      *
-     * @param string $value - endpoint specification value
+     * @param string $mixed - endpoint specification value (can be a string or an array of strings)
      *
      * @return bool - true if endpoint specification is valid, false otherwise
      */
     public static function isValid($value)
     {
-        if (!is_string($value)) {
+        if (is_string($value)) {
+            $value = [ $value ];
+        }
+        
+        if (!is_array($value) || count($value) === 0) {
             return false;
         }
 
-        $type = self::getType($value);
+        foreach ($value as $ep) {
+            if (!is_string($ep)) {
+                return false;
+            }
+            $type = self::getType($ep);
 
-        return !($type === null);
+            if ($type === null) {
+                return false;
+            }
+        }
+        return true;
     }
 
 

--- a/lib/ArangoDBClient/Endpoint.php
+++ b/lib/ArangoDBClient/Endpoint.php
@@ -55,12 +55,12 @@ class Endpoint
     /**
      * Regexp for TCP endpoints
      */
-    const REGEXP_TCP = '/^tcp:\/\/(.+?):(\d+)\/?$/';
+    const REGEXP_TCP = '/^(tcp|http):\/\/(.+?):(\d+)\/?$/';
 
     /**
      * Regexp for SSL endpoints
      */
-    const REGEXP_SSL = '/^ssl:\/\/(.+?):(\d+)\/?$/';
+    const REGEXP_SSL = '/^(ssl|https):\/\/(.+?):(\d+)\/?$/';
 
     /**
      * Regexp for UNIX socket endpoints
@@ -130,6 +130,19 @@ class Endpoint
 
         return null;
     }
+    
+    
+    /**
+     * Return normalize an endpoint string - will convert http: into tcp:, and https: into ssl:
+     *
+     * @param string $value - endpoint string
+     *
+     * @return string - normalized endpoint string
+     */
+    public static function normalize($value)
+    {
+        return preg_replace([ "/http:/", "/https:/" ], [ "tcp:", "ssl:" ], $value);
+    }
 
     /**
      * Return the host name of an endpoint
@@ -141,11 +154,11 @@ class Endpoint
     public static function getHost($value)
     {
         if (preg_match(self::REGEXP_TCP, $value, $matches)) {
-            return $matches[1];
+            return preg_replace("/^http:/", "tcp:", $matches[2]);
         }
 
         if (preg_match(self::REGEXP_SSL, $value, $matches)) {
-            return $matches[1];
+            return preg_replace("/^https:/", "ssl:", $matches[2]);
         }
 
         return null;
@@ -177,7 +190,7 @@ class Endpoint
      *
      * @param Connection $connection - the connection to be used
      *
-     * @link                         https://docs.arangodb.com/HTTP/Endpoints/index.html
+     * @link https://docs.arangodb.com/HTTP/Endpoints/index.html
      * @return array $responseArray - The response array.
      * @throws \ArangoDBClient\Exception
      */

--- a/lib/ArangoDBClient/FailoverException.php
+++ b/lib/ArangoDBClient/FailoverException.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * ArangoDB PHP client: failover exception
+ *
+ * @package   ArangoDBClient
+ * @author    Jan Steemann
+ * @copyright Copyright 2018, ArangoDB GmbH, Cologne, Germany
+ */
+
+namespace ArangoDBClient;
+
+/**
+ * Failover-Exception
+ *
+ * This exception type will be thrown internally when a failover happens
+ *
+ * @package ArangoDBClient
+ * @since   3.3
+ */
+class FailoverException extends Exception
+{
+    /**
+     * New leader endpoint
+     *
+     * @param string
+     */
+    private $_leader;
+    
+    /**
+     * Return a string representation of the exception
+     *
+     * @return string - string representation
+     */
+    public function __toString()
+    {
+        return __CLASS__ . ': ' . $this->getLeader();
+    }
+    
+    /**
+     * Set the new leader endpoint
+     *
+     * @param string - the new leader endpoint
+     *
+     * @return void
+     */
+    public function setLeader($leader)
+    {
+        $this->_leader = $leader;
+    }
+
+    /**
+     * Return the new leader endpoint
+     *
+     * @return string - new leader endpoint
+     */
+    public function getLeader()
+    {
+        return $this->_leader;
+    }
+}
+
+class_alias(FailoverException::class, '\triagens\ArangoDb\Failover');

--- a/lib/ArangoDBClient/HttpHelper.php
+++ b/lib/ArangoDBClient/HttpHelper.php
@@ -81,7 +81,7 @@ class HttpHelper
      */
     public static function createConnection(ConnectionOptions $options)
     {
-        $endpoint = $options[ConnectionOptions::OPTION_ENDPOINT];
+        $endpoint = $options->getCurrentEndpoint();
 
         $context = stream_context_create();
 
@@ -108,7 +108,7 @@ class HttpHelper
         if (!$fp) {
             throw new ConnectException(
                 'cannot connect to endpoint \'' .
-                $options[ConnectionOptions::OPTION_ENDPOINT] . '\': ' . $message, $errNo
+                $endpoint . '\': ' . $message, $errNo
             );
         }
 

--- a/lib/ArangoDBClient/HttpHelper.php
+++ b/lib/ArangoDBClient/HttpHelper.php
@@ -82,7 +82,6 @@ class HttpHelper
     public static function createConnection(ConnectionOptions $options)
     {
         $endpoint = $options->getCurrentEndpoint();
-
         $context = stream_context_create();
 
         if (Endpoint::getType($endpoint) === Endpoint::TYPE_SSL) {

--- a/lib/ArangoDBClient/HttpHelper.php
+++ b/lib/ArangoDBClient/HttpHelper.php
@@ -97,7 +97,7 @@ class HttpHelper
         }
 
         $fp = @stream_socket_client(
-            $endpoint,
+            Endpoint::normalize($endpoint),
             $errNo,
             $message,
             $options[ConnectionOptions::OPTION_TIMEOUT],

--- a/lib/ArangoDBClient/HttpResponse.php
+++ b/lib/ArangoDBClient/HttpResponse.php
@@ -73,6 +73,11 @@ class HttpResponse
      * HTTP location header
      */
     const HEADER_LOCATION = 'location';
+    
+    /**
+     * HTTP leader endpoint header, used in failover
+     */
+    const HEADER_LEADER_ENDPOINT = 'x-arango-endpoint';
 
     /**
      * Set up the response
@@ -163,6 +168,16 @@ class HttpResponse
     public function getLocationHeader()
     {
         return $this->getHeader(self::HEADER_LOCATION);
+    }
+    
+    /**
+     * Return the leader location HTTP header of the response
+     *
+     * @return string - header value, NULL is header wasn't set in response
+     */
+    public function getLeaderEndpointHeader()
+    {
+        return $this->getHeader(self::HEADER_LEADER_ENDPOINT);
     }
 
     /**

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -62,18 +62,38 @@ class ConnectionTest extends
     {
         $options = [ ConnectionOptions::OPTION_ENDPOINT => 'tcp://127.0.0.10:9242' ];
         $co   = new ConnectionOptions($options);
-        static::assertEquals('tcp://127.0.0.10:9242', $co[ConnectionOptions::OPTION_ENDPOINT]);
+        static::assertEquals([ 'tcp://127.0.0.10:9242' ], $co[ConnectionOptions::OPTION_ENDPOINT]);
         static::assertEquals(9242, $co[ConnectionOptions::OPTION_PORT]);
         
         $options = [ ConnectionOptions::OPTION_ENDPOINT => 'tcp://192.168.9.9:433' ];
         $co   = new ConnectionOptions($options);
-        static::assertEquals('tcp://192.168.9.9:433', $co[ConnectionOptions::OPTION_ENDPOINT]);
+        static::assertEquals([ 'tcp://192.168.9.9:433' ], $co[ConnectionOptions::OPTION_ENDPOINT]);
         static::assertEquals(433, $co[ConnectionOptions::OPTION_PORT]);
         
         $options = [ ConnectionOptions::OPTION_ENDPOINT => 'tcp://myserver.example.com:432' ];
         $co   = new ConnectionOptions($options);
-        static::assertEquals('tcp://myserver.example.com:432', $co[ConnectionOptions::OPTION_ENDPOINT]);
+        static::assertEquals([ 'tcp://myserver.example.com:432' ], $co[ConnectionOptions::OPTION_ENDPOINT]);
         static::assertEquals(432, $co[ConnectionOptions::OPTION_PORT]);
+        
+        $options = [ ConnectionOptions::OPTION_ENDPOINT => [ 'tcp://master:8529' ] ];
+        $co   = new ConnectionOptions($options);
+        static::assertEquals([ 'tcp://master:8529' ], $co[ConnectionOptions::OPTION_ENDPOINT]);
+        static::assertEquals(8529, $co[ConnectionOptions::OPTION_PORT]);
+        
+        $options = [ ConnectionOptions::OPTION_ENDPOINT => [ 'tcp://master:1234' ] ];
+        $co   = new ConnectionOptions($options);
+        static::assertEquals([ 'tcp://master:1234' ], $co[ConnectionOptions::OPTION_ENDPOINT]);
+        static::assertEquals(1234, $co[ConnectionOptions::OPTION_PORT]);
+        
+        $options = [ ConnectionOptions::OPTION_ENDPOINT => [ 'tcp://master:8529', 'tcp://slave:1235' ] ];
+        $co   = new ConnectionOptions($options);
+        static::assertEquals([ 'tcp://master:8529', 'tcp://slave:1235' ], $co[ConnectionOptions::OPTION_ENDPOINT]);
+        static::assertEquals(8529, $co[ConnectionOptions::OPTION_PORT]);
+        
+        $options = [ ConnectionOptions::OPTION_ENDPOINT => [ 'tcp://master:8529', 'tcp://slave:8529', 'tcp://blackhole:8529' ] ];
+        $co   = new ConnectionOptions($options);
+        static::assertEquals([ 'tcp://master:8529', 'tcp://slave:8529', 'tcp://blackhole:8529' ], $co[ConnectionOptions::OPTION_ENDPOINT]);
+        static::assertEquals(8529, $co[ConnectionOptions::OPTION_PORT]);
        
         $excepted = false;
         try {


### PR DESCRIPTION
this is not yet ideal, because the driver will still connect to the configured endpoint
every time, only to find out that there is a new leader. it could be significantly
improved by storing the current leader in some sort of cache