### PR TITLE
Add non-existing options keys to return parameters in includeOptionsInParams

### DIFF
--- a/lib/ArangoDBClient/DocumentHandler.php
+++ b/lib/ArangoDBClient/DocumentHandler.php
@@ -806,6 +806,7 @@ class DocumentHandler extends Handler
         return $revision;
     }
 
+
     /**
      * @param       $collection   mixed collection name or id
      * @param array $options      - optional, array of options
@@ -813,10 +814,12 @@ class DocumentHandler extends Handler
      *                            <li>'createCollection' - true to create the collection if it does not exist</li>
      *                            <li>'createCollectionType' - "document" or 2 for document collection</li>
      *                            <li>                         "edge" or 3 for edge collection</li>
+     *                            <li>'waitForSync'       - if set to true, then all removal operations will instantly be synchronised to disk / If this is not specified, then the collection's default sync behavior will be applied.</li>
      *                            </p>
      */
     protected function createCollectionIfOptions($collection, $options)
     {
+
         if (!array_key_exists(CollectionHandler::OPTION_CREATE_COLLECTION, $options)) {
             return;
         }
@@ -829,18 +832,25 @@ class DocumentHandler extends Handler
 
         $collectionHandler = new CollectionHandler($this->getConnection());
 
+        $params = [];
+
         if (array_key_exists('createCollectionType', $options)) {
-            $options['type'] = $options['createCollectionType'];
-            unset($options['createCollectionType']);
+            $params['type'] = $options['createCollectionType'];
         }
-        unset($options['createCollection']);
+
+        if (array_key_exists('waitForSync', $options)) {
+            $params['waitForSync'] = $options['waitForSync'];
+        }
+
         try {
             // attempt to create the collection
-            $collectionHandler->create($collection, $options);
+            $collectionHandler->create($collection, $params);
         } catch (Exception $e) {
             // collection may have existed already
         }
     }
+}
+
 }
 
 class_alias(DocumentHandler::class, '\triagens\ArangoDb\DocumentHandler');

--- a/lib/ArangoDBClient/DocumentHandler.php
+++ b/lib/ArangoDBClient/DocumentHandler.php
@@ -849,7 +849,6 @@ class DocumentHandler extends Handler
             // collection may have existed already
         }
     }
-}
 
 }
 

--- a/lib/ArangoDBClient/Handler.php
+++ b/lib/ArangoDBClient/Handler.php
@@ -111,6 +111,18 @@ abstract class Handler
             }
         }
 
+	foreach ($includeArray as $key => $value) {
+            if (!array_key_exists($key, $options)) {
+                if ($key === ConnectionOptions::OPTION_UPDATE_POLICY) {
+                    UpdatePolicy::validate($value);
+                }
+
+                if ($value !== null) {
+                    $params[$key] = $value;
+                }
+            }
+        }
+
         return $params;
     }
 

--- a/tests/DocumentBasicTest.php
+++ b/tests/DocumentBasicTest.php
@@ -198,6 +198,41 @@ class DocumentBasicTest extends
 
 
     /**
+     * Try to create and delete a document with OPTION_CREATE = true
+     */
+    public function testCreateAndDeleteDocumentWithoutCreatedCollectionAndOptionCreate()
+    {
+        $connection      = $this->connection;
+        $document        = new Document();
+        $documentHandler = new DocumentHandler($connection);
+
+	$options = $connection->getOptions();
+	$connection->setOption(ConnectionOptions::OPTION_CREATE, true);
+
+        try {
+            $this->collectionHandler->drop('ArangoDB_PHP_TestSuite_TestCollection_01' . '_' . static::$testsTimestamp);
+        } catch (\Exception $e) {
+            // don't bother us, if it's already deleted.
+        }
+
+        $document->someAttribute = 'someValue';
+
+        $documentId = $documentHandler->save('ArangoDB_PHP_TestSuite_TestCollection_01' . '_' . static::$testsTimestamp, $document);
+
+        $resultingDocument = $documentHandler->get('ArangoDB_PHP_TestSuite_TestCollection_01' . '_' . static::$testsTimestamp, $documentId);
+
+        $resultingAttribute = $resultingDocument->someAttribute;
+        static::assertSame('someValue', $resultingAttribute, 'Resulting Attribute should be "someValue". It\'s :' . $resultingAttribute);
+
+        $documentHandler->remove($document);
+
+	$connection->setOption(ConnectionOptions::OPTION_CREATE, $options[ConnectionOptions::OPTION_CREATE]);
+
+    }
+
+
+
+    /**
      * Try to create and delete a document using a defined key
      */
     public function testCreateAndDeleteDocumentUsingDefinedKey()


### PR DESCRIPTION
Hello,

The code from tutorial https://www.arangodb.com/tutorials/tutorial-php/ without collection creation will throw an error : 

```php
$connectionOptions = array(
    ArangoDBClient\ConnectionOptions::OPTION_DATABASE => 'database',
    // server endpoint to connect to
    ArangoDBClient\ConnectionOptions::OPTION_ENDPOINT => 'tcp://127.0.0.1:8529',
    // authorization type to use (currently supported: 'Basic')
    ArangoDBClient\ConnectionOptions::OPTION_AUTH_TYPE => 'Basic',
    // user for basic authorization
    ArangoDBClient\ConnectionOptions::OPTION_AUTH_USER => 'root',
    // password for basic authorization
    ArangoDBClient\ConnectionOptions::OPTION_AUTH_PASSWD => '',
    // connection persistence on server. can use either 'Close' (one-time connections) or 'Keep-Alive' (re-used connections)
    ArangoDBClient\ConnectionOptions::OPTION_CONNECTION => 'Close',
    // connect timeout in seconds
    ArangoDBClient\ConnectionOptions::OPTION_TIMEOUT => 3,
    // whether or not to reconnect when a keep-alive connection has timed out on server
    ArangoDBClient\ConnectionOptions::OPTION_RECONNECT => true,
    // optionally create new collections when inserting documents
    ArangoDBClient\ConnectionOptions::OPTION_CREATE => true,
    // optionally create new collections when inserting documents
    ArangoDBClient\ConnectionOptions::OPTION_UPDATE_POLICY => ArangoDBClient\UpdatePolicy::LAST
);

$connection = new ArangoDBClient\Connection($connectionOptions);
$documentHandler = new ArangoDBClient\DocumentHandler($connection);
$document = new ArangoDBClient\Document();
$document->set('title', 'title');

$documentId = $documentHandler->save('collection', $document);
```

```
Fatal error: Uncaught ArangoDBClient\ServerException: 1203 collection or view not found
```

The issue cause in Handler::includeOptionsInParams.  $options parameter of Document::save function by default is empty object [] but Handler::includeOptionsInParams only replaces parameters with existing $options keys. As $options is empty, all parameters are ignored and OPTION_CREATE = true is ignored as well. 

Other way to solve this issue is to assign correct default value to $options parameter of functions.

Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.
