### PR TITLE
issue #281: split OPTION_TIMEOUT into separate options

### DIFF
--- a/examples/init.php
+++ b/examples/init.php
@@ -59,8 +59,9 @@ $connectionOptions = [
     // in order to use an externally generated JWT, there is no need to specify user and passwd, but just the JWT value:
     // ConnectionOptions::OPTION_AUTH_JWT => '',                      // use an externally generated JWT for authorization
 
-    ConnectionOptions::OPTION_TIMEOUT       => 30,                      // timeout in seconds
-    // ConnectionOptions::OPTION_TRACE         => $traceFunc,              // tracer function, can be used for debugging
+    ConnectionOptions::OPTION_CONNECT_TIMEOUT => 10,                    // connect timeout in seconds
+    ConnectionOptions::OPTION_REQUEST_TIMEOUT => 30,                    // request timeout in seconds
+    // ConnectionOptions::OPTION_TRACE         => $traceFunc,           // tracer function, can be used for debugging
     ConnectionOptions::OPTION_CREATE        => false,                   // do not create unknown collections automatically
     ConnectionOptions::OPTION_UPDATE_POLICY => UpdatePolicy::LAST,      // last update wins
 ];

--- a/lib/ArangoDBClient/Connection.php
+++ b/lib/ArangoDBClient/Connection.php
@@ -151,7 +151,8 @@ class Connection
         $this->_options[$name] = $value;
 
         // special handling for several options
-        if ($name === ConnectionOptions::OPTION_TIMEOUT) {
+        if ($name === ConnectionOptions::OPTION_TIMEOUT ||
+            $name === ConnectionOptions::OPTION_REQUEST_TIMEOUT) {
             // set the timeout option: patch the stream of an existing connection
             if (is_resource($this->_handle)) {
                 stream_set_timeout($this->_handle, $value);

--- a/lib/ArangoDBClient/DefaultValues.php
+++ b/lib/ArangoDBClient/DefaultValues.php
@@ -27,8 +27,19 @@ abstract class DefaultValues
 
     /**
      * Default timeout value (used if no timeout value specified)
+     * @deprecated superseded by DEFAULT_CONNECT_TIMEOUT and DEFAULT_REQUEST_TIMEOUT
      */
     const DEFAULT_TIMEOUT = 30;
+    
+    /**
+     * Default connect timeout value (used if no timeout value specified)
+     */
+    const DEFAULT_CONNECT_TIMEOUT = 30;
+    
+    /**
+     * Default request timeout value (used if no timeout value specified)
+     */
+    const DEFAULT_REQUEST_TIMEOUT = 30;
     
     /**
      * Default number of failover servers to try (used in case there is an automatic failover)

--- a/lib/ArangoDBClient/HttpHelper.php
+++ b/lib/ArangoDBClient/HttpHelper.php
@@ -104,7 +104,7 @@ class HttpHelper
             Endpoint::normalize($endpoint),
             $errNo,
             $message,
-            $options[ConnectionOptions::OPTION_TIMEOUT],
+            $options[ConnectionOptions::OPTION_CONNECT_TIMEOUT],
             STREAM_CLIENT_CONNECT,
             $context
         );
@@ -116,7 +116,7 @@ class HttpHelper
             );
         }
 
-        stream_set_timeout($fp, $options[ConnectionOptions::OPTION_TIMEOUT]);
+        stream_set_timeout($fp, $options[ConnectionOptions::OPTION_REQUEST_TIMEOUT]);
 
         return $fp;
     }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -124,17 +124,17 @@ class QueryTest extends
      */
     public function testTimeoutException()
     {
-        $old = $this->connection->getOption(ConnectionOptions::OPTION_TIMEOUT);
-        $this->connection->setOption(ConnectionOptions::OPTION_TIMEOUT, 10);
+        $old = $this->connection->getOption(ConnectionOptions::OPTION_REQUEST_TIMEOUT);
+        $this->connection->setOption(ConnectionOptions::OPTION_REQUEST_TIMEOUT, 10);
         $query = 'RETURN SLEEP(13)';
 
         $statement = new Statement($this->connection, ['query' => $query]);
 
         try {
             $statement->execute();
-            $this->connection->setOption(ConnectionOptions::OPTION_TIMEOUT, $old);
+            $this->connection->setOption(ConnectionOptions::OPTION_REQUEST_TIMEOUT, $old);
         } catch (ClientException $exception) {
-            $this->connection->setOption(ConnectionOptions::OPTION_TIMEOUT, $old);
+            $this->connection->setOption(ConnectionOptions::OPTION_REQUEST_TIMEOUT, $old);
             static::assertEquals($exception->getCode(), 408);
             throw $exception;
         }


### PR DESCRIPTION
OPTION_TIMEOUT is now superseded by the more specialized options
- OPTION_CONNECT_TIMEOUT
- OPTION_REQUEST_TIMEOUT

The existing OPTION_TIMEOUT value can still be used as before. When
used, it will automatically clobber values set in OPTION_CONNECT_TIMEOUT
and OPTION_REQUEST_TIMEOUT.
Using one of the more specialized options will remove OPTION_TIMEOUT
from the connection's option.