### PR TITLE
issue #269: Undefined index: revision

### DIFF
--- a/lib/ArangoDBClient/DocumentHandler.php
+++ b/lib/ArangoDBClient/DocumentHandler.php
@@ -757,9 +757,10 @@ class DocumentHandler extends Handler
         if (isset($params[ConnectionOptions::OPTION_REPLACE_POLICY]) &&
             $params[ConnectionOptions::OPTION_REPLACE_POLICY] === UpdatePolicy::ERROR
         ) {
-            if (null !== $options['revision']) {
+            $revision = $document->getRevision();
+            if (null !== $revision) {
                 $params['ignoreRevs'] = false;
-                $headers['if-match']  = '"' . $options['revision'] . '"';
+                $headers['if-match']  = '"' . $revision . '"';
             }
         }
         


### PR DESCRIPTION
Fix an undefined index notice/warning when calling the
DocumentHandler::put function with a `revision` option set.